### PR TITLE
Implement gmail.getMessage retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ It runs as a separate Linux process and user, exposes a narrow tool API over a U
   - Creates a dedicated Pub/Sub subscription on startup.
   - Deletes that subscription during shutdown.
   - Relays Gmail notification events to the configured OpenClaw webhook.
-- Initial tool methods are implemented with placeholder provider integrations:
+- Initial tool methods are available:
   - `gmail.getMessage`
-  - `calendar.listEvents`
+  - `calendar.listEvents` (provider integration placeholder)
 
 ## Documentation
 - Usage guide: `docs/usage.md`
@@ -72,9 +72,12 @@ Example:
 export OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN="replace-me"
 export OC_GCP_PROJECT_ID="my-gcp-project"
 export OC_GCP_GMAIL_PUBSUB_TOPIC_ID="gmail-notifications"
+export OC_GCP_CREDENTIALS_FILE="/var/lib/oc-companion/gcp-credentials.json"
 go run ./cmd/oc-companion
 ```
 
 If `OC_OPENCLAW_GMAIL_WEBHOOK_URL` is not set, `oc-companion` defaults to `http://127.0.0.1:18789/hooks/gmail`.
+
+`gmail.getMessage` uses the same Google credential chain as the Pub/Sub receiver. Those credentials must also be authorized for Gmail readonly access to the mailbox being queried.
 
 Then connect to the configured Unix socket and call `system.discover` first to enumerate available tools and metadata.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,15 @@ export OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN="replace-me"
 export OC_GCP_PROJECT_ID="my-gcp-project"
 export OC_GCP_GMAIL_PUBSUB_TOPIC_ID="gmail-notifications"
 export OC_GCP_CREDENTIALS_FILE="/var/lib/oc-companion/gcp-credentials.json"
+export OC_GMAIL_DELEGATED_SUBJECT="user@example.com"
+export OC_GMAIL_USER_ID="user@example.com"
 go run ./cmd/oc-companion
 ```
 
 If `OC_OPENCLAW_GMAIL_WEBHOOK_URL` is not set, `oc-companion` defaults to `http://127.0.0.1:18789/hooks/gmail`.
 
-`gmail.getMessage` uses the same Google credential chain as the Pub/Sub receiver. Those credentials must also be authorized for Gmail readonly access to the mailbox being queried.
+`gmail.getMessage` uses the same Google credential chain as the Pub/Sub receiver and fetches full Gmail message payloads so body fallback works when `snippet` is empty.
+Those credentials must also be authorized for Gmail readonly access to the mailbox being queried.
+If you use a service account, set `OC_GMAIL_DELEGATED_SUBJECT` to the mailbox user and optionally `OC_GMAIL_USER_ID` to the mailbox address you want Gmail API calls to target.
 
 Then connect to the configured Unix socket and call `system.discover` first to enumerate available tools and metadata.

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,9 +19,11 @@
 export OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN="replace-me"
 export OC_GCP_PROJECT_ID="my-gcp-project"
 export OC_GCP_GMAIL_PUBSUB_TOPIC_ID="gmail-notifications"
+export OC_GCP_CREDENTIALS_FILE="/var/lib/oc-companion/gcp-credentials.json"
 ```
 
 By default, the companion sends Gmail event callbacks to `http://127.0.0.1:18789/hooks/gmail`.
+Those credentials must be valid for both Pub/Sub access and Gmail readonly message retrieval if you want `gmail.getMessage` to work locally.
 
 ## Build and Test
 Build:

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,10 +20,13 @@ export OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN="replace-me"
 export OC_GCP_PROJECT_ID="my-gcp-project"
 export OC_GCP_GMAIL_PUBSUB_TOPIC_ID="gmail-notifications"
 export OC_GCP_CREDENTIALS_FILE="/var/lib/oc-companion/gcp-credentials.json"
+export OC_GMAIL_DELEGATED_SUBJECT="user@example.com"
+export OC_GMAIL_USER_ID="user@example.com"
 ```
 
 By default, the companion sends Gmail event callbacks to `http://127.0.0.1:18789/hooks/gmail`.
 Those credentials must be valid for both Pub/Sub access and Gmail readonly message retrieval if you want `gmail.getMessage` to work locally.
+If your local setup uses a service account, `OC_GMAIL_DELEGATED_SUBJECT` is the mailbox identity used for delegated Gmail reads, and `OC_GMAIL_USER_ID` lets you override the Gmail API user target instead of relying on `me`.
 
 ## Build and Test
 Build:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,11 +33,14 @@ Optional:
 export OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN="replace-me"
 export OC_GCP_PROJECT_ID="my-gcp-project"
 export OC_GCP_GMAIL_PUBSUB_TOPIC_ID="gmail-notifications"
+export OC_GCP_CREDENTIALS_FILE="/var/lib/oc-companion/gcp-credentials.json"
 export OC_COMPANION_SOCKET_PATH="/tmp/oc-companion.sock"
 go run ./cmd/oc-companion
 ```
 
 If you do not set `OC_OPENCLAW_GMAIL_WEBHOOK_URL`, `oc-companion` posts Gmail notifications to `http://127.0.0.1:18789/hooks/gmail`.
+
+For `gmail.getMessage`, the configured Google credentials must also be able to read the target mailbox with Gmail readonly access.
 
 ## Client Interaction (Simplest Path)
 1. Connect to the Unix socket.
@@ -61,13 +64,13 @@ Ping:
 {"id":"2","method":"system.ping"}
 ```
 
-Gmail message lookup (contract in place; provider integration pending):
+Gmail message lookup:
 
 ```json
 {"id":"3","method":"gmail.getMessage","params":{"message_id":"18c2b"}}
 ```
 
-Calendar events lookup (contract in place; provider integration pending):
+Calendar events lookup (provider integration pending):
 
 ```json
 {"id":"4","method":"calendar.listEvents","params":{"start":"2026-03-14T00:00:00Z","end":"2026-03-15T00:00:00Z","max_results":10}}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,6 +20,8 @@ Required:
 Optional:
 - `OC_OPENCLAW_GMAIL_WEBHOOK_URL` (default: `http://127.0.0.1:18789/hooks/gmail`)
 - `OC_GCP_CREDENTIALS_FILE` (if omitted, Application Default Credentials are used)
+- `OC_GMAIL_USER_ID` (default: `me`; set to a mailbox address to target a specific Gmail user)
+- `OC_GMAIL_DELEGATED_SUBJECT` (optional delegated subject for service-account domain-wide delegation)
 - `OC_GCP_PUBSUB_SUBSCRIPTION_PREFIX` (default: `oc-companion-gmail`)
 - `OC_COMPANION_SOCKET_PATH` (default: `/run/oc-companion/companion.sock`)
 - `OC_COMPANION_LOG_LEVEL` (`debug`, `info`, `warn`, `error`; default: `info`)
@@ -34,6 +36,8 @@ export OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN="replace-me"
 export OC_GCP_PROJECT_ID="my-gcp-project"
 export OC_GCP_GMAIL_PUBSUB_TOPIC_ID="gmail-notifications"
 export OC_GCP_CREDENTIALS_FILE="/var/lib/oc-companion/gcp-credentials.json"
+export OC_GMAIL_DELEGATED_SUBJECT="user@example.com"
+export OC_GMAIL_USER_ID="user@example.com"
 export OC_COMPANION_SOCKET_PATH="/tmp/oc-companion.sock"
 go run ./cmd/oc-companion
 ```
@@ -41,6 +45,8 @@ go run ./cmd/oc-companion
 If you do not set `OC_OPENCLAW_GMAIL_WEBHOOK_URL`, `oc-companion` posts Gmail notifications to `http://127.0.0.1:18789/hooks/gmail`.
 
 For `gmail.getMessage`, the configured Google credentials must also be able to read the target mailbox with Gmail readonly access.
+When `snippet` is empty, the companion falls back to the full Gmail body payload.
+If you use a service account for Pub/Sub, set `OC_GMAIL_DELEGATED_SUBJECT` so Gmail API calls are delegated to a mailbox user instead of the service account principal.
 
 ## Client Interaction (Simplest Path)
 1. Connect to the Unix socket.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -87,7 +87,11 @@ func (a *App) Run(ctx context.Context) error {
 }
 
 func newServices(ctx context.Context, cfg config.Config) (tools.Services, error) {
-	gmailService, err := tools.NewGmailService(ctx, cfg.GCPCredentialsFile)
+	gmailService, err := tools.NewGmailService(ctx, tools.GmailServiceConfig{
+		CredentialsFile:  cfg.GCPCredentialsFile,
+		UserID:           cfg.GmailUserID,
+		DelegatedSubject: cfg.GmailDelegatedSubject,
+	})
 	if err != nil {
 		return tools.Services{}, err
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,7 +25,12 @@ func New(cfg config.Config) *App {
 func (a *App) Run(ctx context.Context) error {
 	logger := slog.Default()
 	registry := api.NewRegistry()
-	if err := tools.Register(registry, tools.NewUnavailableServices()); err != nil {
+	services, err := newServices(ctx, a.cfg)
+	if err != nil {
+		return err
+	}
+
+	if err := tools.Register(registry, services); err != nil {
 		return err
 	}
 
@@ -79,6 +84,17 @@ func (a *App) Run(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+func newServices(ctx context.Context, cfg config.Config) (tools.Services, error) {
+	gmailService, err := tools.NewGmailService(ctx, cfg.GCPCredentialsFile)
+	if err != nil {
+		return tools.Services{}, err
+	}
+
+	services := tools.NewUnavailableServices()
+	services.Gmail = gmailService
+	return services, nil
 }
 
 func newEventWorker(ctx context.Context, cfg config.Config, logger *slog.Logger) (events.Worker, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	SocketPath               string
 	GmailWebhookURL          string
 	GmailWebhookToken        string
+	GmailUserID              string
+	GmailDelegatedSubject    string
 	GCPProjectID             string
 	GmailPubSubTopicID       string
 	GCPCredentialsFile       string
@@ -35,6 +37,8 @@ func Load() (Config, error) {
 		SocketPath:               getEnv("OC_COMPANION_SOCKET_PATH", defaultAddr),
 		GmailWebhookURL:          getFirstEnvWithFallback(defaultGmailWebhookURL, "OC_OPENCLAW_GMAIL_WEBHOOK_URL", "OC_OPENCLAW_WEBHOOK_BASE_URL"),
 		GmailWebhookToken:        strings.TrimSpace(os.Getenv("OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN")),
+		GmailUserID:              strings.TrimSpace(os.Getenv("OC_GMAIL_USER_ID")),
+		GmailDelegatedSubject:    strings.TrimSpace(os.Getenv("OC_GMAIL_DELEGATED_SUBJECT")),
 		GCPProjectID:             strings.TrimSpace(os.Getenv("OC_GCP_PROJECT_ID")),
 		GmailPubSubTopicID:       strings.TrimSpace(os.Getenv("OC_GCP_GMAIL_PUBSUB_TOPIC_ID")),
 		GCPCredentialsFile:       strings.TrimSpace(os.Getenv("OC_GCP_CREDENTIALS_FILE")),
@@ -132,9 +136,11 @@ func normalizeFormat(value string) string {
 
 func (c Config) Summary() string {
 	return fmt.Sprintf(
-		"socket=%s gmail_webhook=%s gcp_project=%s gmail_topic=%s subscription_prefix=%s log_level=%s log_format=%s shutdown_timeout=%s",
+		"socket=%s gmail_webhook=%s gmail_user=%s gmail_delegated_subject=%t gcp_project=%s gmail_topic=%s subscription_prefix=%s log_level=%s log_format=%s shutdown_timeout=%s",
 		c.SocketPath,
 		c.GmailWebhookURL,
+		summaryGmailUserID(c.GmailUserID),
+		c.GmailDelegatedSubject != "",
 		c.GCPProjectID,
 		c.GmailPubSubTopicID,
 		c.PubSubSubscriptionPrefix,
@@ -164,6 +170,15 @@ func sanitizeSubscriptionPrefix(value string) string {
 	}
 	if value[0] < 'a' || value[0] > 'z' {
 		return "oc-" + value
+	}
+
+	return value
+}
+
+func summaryGmailUserID(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "me"
 	}
 
 	return value

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,41 @@ func TestLoad_AllowsLegacyWebhookEnvName(t *testing.T) {
 	}
 }
 
+func TestLoad_DefaultsGmailUserIDAndAllowsDelegatedSubject(t *testing.T) {
+	t.Setenv("OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN", "secret-token")
+	t.Setenv("OC_GCP_PROJECT_ID", "my-project")
+	t.Setenv("OC_GCP_GMAIL_PUBSUB_TOPIC_ID", "gmail-topic")
+	t.Setenv("OC_GMAIL_DELEGATED_SUBJECT", "delegate@example.com")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected config to load: %v", err)
+	}
+
+	if cfg.GmailUserID != "" {
+		t.Fatalf("expected empty configured gmail user id, got %q", cfg.GmailUserID)
+	}
+	if cfg.GmailDelegatedSubject != "delegate@example.com" {
+		t.Fatalf("expected delegated subject, got %q", cfg.GmailDelegatedSubject)
+	}
+}
+
+func TestLoad_AllowsCustomGmailUserID(t *testing.T) {
+	t.Setenv("OC_OPENCLAW_GMAIL_WEBHOOK_TOKEN", "secret-token")
+	t.Setenv("OC_GCP_PROJECT_ID", "my-project")
+	t.Setenv("OC_GCP_GMAIL_PUBSUB_TOPIC_ID", "gmail-topic")
+	t.Setenv("OC_GMAIL_USER_ID", "mailbox@example.com")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("expected config to load: %v", err)
+	}
+
+	if cfg.GmailUserID != "mailbox@example.com" {
+		t.Fatalf("expected custom gmail user id, got %q", cfg.GmailUserID)
+	}
+}
+
 func TestSanitizeSubscriptionPrefix(t *testing.T) {
 	got := sanitizeSubscriptionPrefix("123 bad.prefix")
 	if got != "oc-123-bad-prefix" {

--- a/internal/tools/gmail.go
+++ b/internal/tools/gmail.go
@@ -1,0 +1,235 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"html"
+	"mime"
+	"net/mail"
+	"strings"
+	"time"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/option"
+)
+
+const gmailReadonlyScope = gmail.GmailReadonlyScope
+
+type gmailMessagesAPI interface {
+	Get(userID string, messageID string) gmailMessageGetCall
+}
+
+type gmailMessageGetCall interface {
+	Format(format string) gmailMessageGetCall
+	Context(ctx context.Context) gmailMessageGetCall
+	Do(...googleCallOption) (*gmail.Message, error)
+}
+
+type googleCallOption = googleapi.CallOption
+
+type gmailAPIService struct {
+	messages gmailMessagesAPI
+}
+
+func NewGmailService(ctx context.Context, credentialsFile string) (GmailService, error) {
+	options := []option.ClientOption{option.WithScopes(gmailReadonlyScope)}
+	if credentialsFile = strings.TrimSpace(credentialsFile); credentialsFile != "" {
+		options = append(options, option.WithCredentialsFile(credentialsFile))
+	}
+
+	service, err := gmail.NewService(ctx, options...)
+	if err != nil {
+		return nil, fmt.Errorf("create gmail service: %w", err)
+	}
+
+	return &gmailAPIService{messages: &gmailMessagesClient{service: service.Users.Messages}}, nil
+}
+
+func (s *gmailAPIService) GetMessage(ctx context.Context, messageID string) (GmailMessage, error) {
+	message, err := s.messages.Get("me", messageID).Format("metadata").Context(ctx).Do()
+	if err != nil {
+		return GmailMessage{}, fmt.Errorf("gmail messages.get %q: %w", messageID, err)
+	}
+
+	return normalizeGmailMessage(message)
+}
+
+type gmailMessagesClient struct {
+	service *gmail.UsersMessagesService
+}
+
+func (c *gmailMessagesClient) Get(userID string, messageID string) gmailMessageGetCall {
+	return &gmailMessageCall{call: c.service.Get(userID, messageID)}
+}
+
+type gmailMessageCall struct {
+	call *gmail.UsersMessagesGetCall
+}
+
+func (c *gmailMessageCall) Format(format string) gmailMessageGetCall {
+	c.call = c.call.Format(format)
+	return c
+}
+
+func (c *gmailMessageCall) Context(ctx context.Context) gmailMessageGetCall {
+	c.call = c.call.Context(ctx)
+	return c
+}
+
+func (c *gmailMessageCall) Do(opts ...googleCallOption) (*gmail.Message, error) {
+	return c.call.Do(opts...)
+}
+
+func normalizeGmailMessage(message *gmail.Message) (GmailMessage, error) {
+	if message == nil {
+		return GmailMessage{}, errors.New("gmail message is nil")
+	}
+
+	receivedAt, err := parseReceivedAt(message.InternalDate, headerValue(message.Payload, "Date"))
+	if err != nil {
+		return GmailMessage{}, err
+	}
+
+	return GmailMessage{
+		ID:         strings.TrimSpace(message.Id),
+		ThreadID:   strings.TrimSpace(message.ThreadId),
+		From:       decodeHeader(headerValue(message.Payload, "From")),
+		To:         decodeHeader(headerValue(message.Payload, "To")),
+		Subject:    decodeHeader(headerValue(message.Payload, "Subject")),
+		Snippet:    normalizeSnippet(message.Snippet, message.Payload),
+		ReceivedAt: receivedAt,
+	}, nil
+}
+
+func headerValue(payload *gmail.MessagePart, name string) string {
+	if payload == nil {
+		return ""
+	}
+
+	for _, header := range payload.Headers {
+		if strings.EqualFold(strings.TrimSpace(header.Name), name) {
+			return strings.TrimSpace(header.Value)
+		}
+	}
+
+	return ""
+}
+
+func decodeHeader(value string) string {
+	decoded := strings.TrimSpace(value)
+	if decoded == "" {
+		return ""
+	}
+
+	decoder := new(mime.WordDecoder)
+	if result, err := decoder.DecodeHeader(decoded); err == nil {
+		return result
+	}
+
+	return decoded
+}
+
+func parseReceivedAt(internalDate int64, dateHeader string) (time.Time, error) {
+	if internalDate > 0 {
+		return time.UnixMilli(internalDate).UTC(), nil
+	}
+
+	if value := strings.TrimSpace(dateHeader); value != "" {
+		parsed, err := mailParseDate(value)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parse date header: %w", err)
+		}
+
+		return parsed.UTC(), nil
+	}
+
+	return time.Time{}, errors.New("gmail message missing received timestamp")
+}
+
+func normalizeSnippet(snippet string, payload *gmail.MessagePart) string {
+	snippet = strings.TrimSpace(snippet)
+	if snippet != "" {
+		return snippet
+	}
+
+	if body := strings.TrimSpace(extractTextBody(payload)); body != "" {
+		return body
+	}
+
+	return ""
+}
+
+func extractTextBody(part *gmail.MessagePart) string {
+	if part == nil {
+		return ""
+	}
+
+	if isTextBodyPart(part) {
+		if decoded := decodeBody(part.Body); decoded != "" {
+			return decoded
+		}
+	}
+
+	for _, child := range part.Parts {
+		if body := extractTextBody(child); body != "" {
+			return body
+		}
+	}
+
+	return ""
+}
+
+func isTextBodyPart(part *gmail.MessagePart) bool {
+	mimeType := strings.ToLower(strings.TrimSpace(part.MimeType))
+	return mimeType == "text/plain" || mimeType == "text/html"
+}
+
+func decodeBody(body *gmail.MessagePartBody) string {
+	if body == nil || strings.TrimSpace(body.Data) == "" {
+		return ""
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(body.Data)
+	if err != nil {
+		return ""
+	}
+
+	text := strings.TrimSpace(string(decoded))
+	if text == "" {
+		return ""
+	}
+
+	text = strings.NewReplacer("\r\n", "\n", "\r", "\n", "\t", " ").Replace(text)
+	if strings.Contains(strings.ToLower(text), "<html") || strings.Contains(strings.ToLower(text), "<body") {
+		text = stripHTML(text)
+	}
+
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func stripHTML(value string) string {
+	var builder strings.Builder
+	inTag := false
+	for _, r := range value {
+		switch r {
+		case '<':
+			inTag = true
+		case '>':
+			inTag = false
+			builder.WriteRune(' ')
+		default:
+			if !inTag {
+				builder.WriteRune(r)
+			}
+		}
+	}
+
+	return html.UnescapeString(builder.String())
+}
+
+var mailParseDate = func(value string) (time.Time, error) {
+	return mail.ParseDate(value)
+}

--- a/internal/tools/gmail.go
+++ b/internal/tools/gmail.go
@@ -8,9 +8,12 @@ import (
 	"html"
 	"mime"
 	"net/mail"
+	"os"
 	"strings"
 	"time"
 
+	"golang.org/x/oauth2"
+	googoauth "golang.org/x/oauth2/google"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -32,24 +35,23 @@ type googleCallOption = googleapi.CallOption
 
 type gmailAPIService struct {
 	messages gmailMessagesAPI
+	userID   string
 }
 
-func NewGmailService(ctx context.Context, credentialsFile string) (GmailService, error) {
-	options := []option.ClientOption{option.WithScopes(gmailReadonlyScope)}
-	if credentialsFile = strings.TrimSpace(credentialsFile); credentialsFile != "" {
-		options = append(options, option.WithCredentialsFile(credentialsFile))
-	}
-
-	service, err := gmail.NewService(ctx, options...)
+func NewGmailService(ctx context.Context, cfg GmailServiceConfig) (GmailService, error) {
+	service, err := newGmailAPIClient(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("create gmail service: %w", err)
+		return nil, err
 	}
 
-	return &gmailAPIService{messages: &gmailMessagesClient{service: service.Users.Messages}}, nil
+	return &gmailAPIService{
+		messages: &gmailMessagesClient{service: service.Users.Messages},
+		userID:   resolveGmailUserID(cfg.UserID, cfg.DelegatedSubject),
+	}, nil
 }
 
 func (s *gmailAPIService) GetMessage(ctx context.Context, messageID string) (GmailMessage, error) {
-	message, err := s.messages.Get("me", messageID).Format("metadata").Context(ctx).Do()
+	message, err := s.messages.Get(s.userID, messageID).Format("full").Context(ctx).Do()
 	if err != nil {
 		return GmailMessage{}, fmt.Errorf("gmail messages.get %q: %w", messageID, err)
 	}
@@ -81,6 +83,73 @@ func (c *gmailMessageCall) Context(ctx context.Context) gmailMessageGetCall {
 
 func (c *gmailMessageCall) Do(opts ...googleCallOption) (*gmail.Message, error) {
 	return c.call.Do(opts...)
+}
+
+func newGmailAPIClient(ctx context.Context, cfg GmailServiceConfig) (*gmail.Service, error) {
+	if strings.TrimSpace(cfg.DelegatedSubject) == "" {
+		options := []option.ClientOption{option.WithScopes(gmailReadonlyScope)}
+		if credentialsFile := strings.TrimSpace(cfg.CredentialsFile); credentialsFile != "" {
+			options = append(options, option.WithCredentialsFile(credentialsFile))
+		}
+
+		service, err := gmail.NewService(ctx, options...)
+		if err != nil {
+			return nil, fmt.Errorf("create gmail service: %w", err)
+		}
+
+		return service, nil
+	}
+
+	tokenSource, err := newDelegatedTokenSource(ctx, cfg.CredentialsFile, cfg.DelegatedSubject)
+	if err != nil {
+		return nil, err
+	}
+
+	service, err := gmail.NewService(ctx, option.WithTokenSource(tokenSource))
+	if err != nil {
+		return nil, fmt.Errorf("create gmail service: %w", err)
+	}
+
+	return service, nil
+}
+
+func newDelegatedTokenSource(ctx context.Context, credentialsFile string, delegatedSubject string) (oauth2.TokenSource, error) {
+	params := googoauth.CredentialsParams{
+		Scopes:  []string{gmailReadonlyScope},
+		Subject: strings.TrimSpace(delegatedSubject),
+	}
+
+	var (
+		creds *googoauth.Credentials
+		err   error
+	)
+
+	if credentialsFile = strings.TrimSpace(credentialsFile); credentialsFile != "" {
+		data, readErr := os.ReadFile(credentialsFile)
+		if readErr != nil {
+			return nil, fmt.Errorf("read gmail credentials file: %w", readErr)
+		}
+
+		creds, err = googoauth.CredentialsFromJSONWithParams(ctx, data, params)
+	} else {
+		creds, err = googoauth.FindDefaultCredentialsWithParams(ctx, params)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create delegated gmail credentials: %w", err)
+	}
+
+	return creds.TokenSource, nil
+}
+
+func resolveGmailUserID(userID string, delegatedSubject string) string {
+	if userID = strings.TrimSpace(userID); userID != "" {
+		return userID
+	}
+	if delegatedSubject = strings.TrimSpace(delegatedSubject); delegatedSubject != "" {
+		return delegatedSubject
+	}
+
+	return "me"
 }
 
 func normalizeGmailMessage(message *gmail.Message) (GmailMessage, error) {

--- a/internal/tools/gmail_test.go
+++ b/internal/tools/gmail_test.go
@@ -73,21 +73,21 @@ func TestGmailAPIServiceGetMessage_UsesMetadataFormatAndNormalizesMessage(t *tes
 		},
 	}
 	api := &fakeGmailMessagesAPI{call: call}
-	service := &gmailAPIService{messages: api}
+	service := &gmailAPIService{messages: api, userID: "mailbox@example.com"}
 
 	message, err := service.GetMessage(context.Background(), "msg-1")
 	if err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 
-	if api.userID != "me" {
-		t.Fatalf("expected userID me, got %q", api.userID)
+	if api.userID != "mailbox@example.com" {
+		t.Fatalf("expected configured userID, got %q", api.userID)
 	}
 	if api.messageID != "msg-1" {
 		t.Fatalf("expected message id to be forwarded, got %q", api.messageID)
 	}
-	if call.format != "metadata" {
-		t.Fatalf("expected metadata format, got %q", call.format)
+	if call.format != "full" {
+		t.Fatalf("expected full format, got %q", call.format)
 	}
 	if message.Subject != "Hello ✓" {
 		t.Fatalf("expected decoded subject, got %q", message.Subject)
@@ -98,6 +98,38 @@ func TestGmailAPIServiceGetMessage_UsesMetadataFormatAndNormalizesMessage(t *tes
 	expectedReceivedAt := time.UnixMilli(1710117296000).UTC()
 	if !message.ReceivedAt.Equal(expectedReceivedAt) {
 		t.Fatalf("expected received_at %s, got %s", expectedReceivedAt, message.ReceivedAt)
+	}
+}
+
+func TestResolveGmailUserID(t *testing.T) {
+	tests := []struct {
+		name             string
+		userID           string
+		delegatedSubject string
+		want             string
+	}{
+		{
+			name: "defaults to me",
+			want: "me",
+		},
+		{
+			name:   "uses explicit user id",
+			userID: "mailbox@example.com",
+			want:   "mailbox@example.com",
+		},
+		{
+			name:             "falls back to delegated subject",
+			delegatedSubject: "delegate@example.com",
+			want:             "delegate@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveGmailUserID(tt.userID, tt.delegatedSubject); got != tt.want {
+				t.Fatalf("expected user id %q, got %q", tt.want, got)
+			}
+		})
 	}
 }
 

--- a/internal/tools/gmail_test.go
+++ b/internal/tools/gmail_test.go
@@ -1,0 +1,143 @@
+package tools
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+type fakeGmailMessagesAPI struct {
+	userID    string
+	messageID string
+	call      *fakeGmailMessageGetCall
+}
+
+func (f *fakeGmailMessagesAPI) Get(userID string, messageID string) gmailMessageGetCall {
+	f.userID = userID
+	f.messageID = messageID
+	return f.call
+}
+
+type fakeGmailMessageGetCall struct {
+	format  string
+	ctx     context.Context
+	message *gmail.Message
+	err     error
+}
+
+func (f *fakeGmailMessageGetCall) Format(format string) gmailMessageGetCall {
+	f.format = format
+	return f
+}
+
+func (f *fakeGmailMessageGetCall) Context(ctx context.Context) gmailMessageGetCall {
+	f.ctx = ctx
+	return f
+}
+
+func (f *fakeGmailMessageGetCall) Do(...googleCallOption) (*gmail.Message, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	return f.message, nil
+}
+
+func TestGmailAPIServiceGetMessage_UsesMetadataFormatAndNormalizesMessage(t *testing.T) {
+	call := &fakeGmailMessageGetCall{
+		message: &gmail.Message{
+			Id:           "msg-1",
+			ThreadId:     "thread-1",
+			InternalDate: 1710117296000,
+			Snippet:      "",
+			Payload: &gmail.MessagePart{
+				MimeType: "multipart/alternative",
+				Headers: []*gmail.MessagePartHeader{
+					{Name: "From", Value: "Sender <sender@example.com>"},
+					{Name: "To", Value: "Receiver <receiver@example.com>"},
+					{Name: "Subject", Value: "=?UTF-8?Q?Hello_=E2=9C=93?="},
+				},
+				Parts: []*gmail.MessagePart{
+					{
+						MimeType: "text/plain",
+						Body: &gmail.MessagePartBody{
+							Data: base64.URLEncoding.EncodeToString([]byte("Hello from Gmail body")),
+						},
+					},
+				},
+			},
+		},
+	}
+	api := &fakeGmailMessagesAPI{call: call}
+	service := &gmailAPIService{messages: api}
+
+	message, err := service.GetMessage(context.Background(), "msg-1")
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	if api.userID != "me" {
+		t.Fatalf("expected userID me, got %q", api.userID)
+	}
+	if api.messageID != "msg-1" {
+		t.Fatalf("expected message id to be forwarded, got %q", api.messageID)
+	}
+	if call.format != "metadata" {
+		t.Fatalf("expected metadata format, got %q", call.format)
+	}
+	if message.Subject != "Hello ✓" {
+		t.Fatalf("expected decoded subject, got %q", message.Subject)
+	}
+	if message.Snippet != "Hello from Gmail body" {
+		t.Fatalf("expected normalized snippet from body, got %q", message.Snippet)
+	}
+	expectedReceivedAt := time.UnixMilli(1710117296000).UTC()
+	if !message.ReceivedAt.Equal(expectedReceivedAt) {
+		t.Fatalf("expected received_at %s, got %s", expectedReceivedAt, message.ReceivedAt)
+	}
+}
+
+func TestGmailAPIServiceGetMessage_ReturnsWrappedError(t *testing.T) {
+	service := &gmailAPIService{
+		messages: &fakeGmailMessagesAPI{
+			call: &fakeGmailMessageGetCall{err: errors.New("boom")},
+		},
+	}
+
+	_, err := service.GetMessage(context.Background(), "msg-2")
+	if err == nil || err.Error() != `gmail messages.get "msg-2": boom` {
+		t.Fatalf("expected wrapped gmail get error, got %v", err)
+	}
+}
+
+func TestNormalizeGmailMessage_FallsBackToDateHeader(t *testing.T) {
+	message, err := normalizeGmailMessage(&gmail.Message{
+		Id:       "msg-3",
+		ThreadId: "thread-3",
+		Snippet:  "Header fallback",
+		Payload: &gmail.MessagePart{
+			Headers: []*gmail.MessagePartHeader{
+				{Name: "Date", Value: "Mon, 11 Mar 2024 15:14:56 +0000"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	expected := time.Date(2024, time.March, 11, 15, 14, 56, 0, time.UTC)
+	if !message.ReceivedAt.Equal(expected) {
+		t.Fatalf("expected received_at %s, got %s", expected, message.ReceivedAt)
+	}
+}
+
+func TestNormalizeGmailMessage_RequiresTimestamp(t *testing.T) {
+	_, err := normalizeGmailMessage(&gmail.Message{Id: "msg-4"})
+	if err == nil || err.Error() != "gmail message missing received timestamp" {
+		t.Fatalf("expected missing timestamp error, got %v", err)
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -25,6 +25,12 @@ type CalendarEvent struct {
 	Location    string    `json:"location,omitempty"`
 }
 
+type GmailServiceConfig struct {
+	CredentialsFile  string
+	UserID           string
+	DelegatedSubject string
+}
+
 type GmailService interface {
 	GetMessage(context.Context, string) (GmailMessage, error)
 }


### PR DESCRIPTION
## Summary
- add a Gmail API-backed implementation for 
- normalize Gmail message metadata into the existing tool response shape
- document that the configured Google credentials must allow Gmail readonly access

## Validation
- GOCACHE=/tmp/oc-companion-go-build-cache GOMODCACHE=/tmp/oc-companion-go-mod-cache GOPATH=/tmp/oc-companion-go /usr/local/go/bin/go test ./...
- GOCACHE=/tmp/oc-companion-go-build-cache GOMODCACHE=/tmp/oc-companion-go-mod-cache GOPATH=/tmp/oc-companion-go /usr/local/go/bin/go build -buildvcs=false ./...

Closes #6